### PR TITLE
Fix ADG alerts as they are triggered rules not metrics so they do not…

### DIFF
--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -133,7 +133,6 @@ resource "aws_cloudwatch_metric_alarm" "clive_failed" {
   statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "This metric monitors cluster termination with errors"
-  treat_missing_data        = "ignore"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
@@ -160,7 +159,6 @@ resource "aws_cloudwatch_metric_alarm" "clive_terminated" {
   statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "This metric monitors cluster terminated by user request"
-  treat_missing_data        = "ignore"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
@@ -187,7 +185,6 @@ resource "aws_cloudwatch_metric_alarm" "clive_success" {
   statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "Monitoring clive completion"
-  treat_missing_data        = "ignore"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
@@ -214,7 +211,6 @@ resource "aws_cloudwatch_metric_alarm" "clive_success_with_errors" {
   statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "Monitoring clive completion with non-critical errors"
-  treat_missing_data        = "ignore"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {
@@ -241,7 +237,6 @@ resource "aws_cloudwatch_metric_alarm" "clive_running" {
   statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "Monitoring clive completion"
-  treat_missing_data        = "ignore"
   insufficient_data_actions = []
   alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   dimensions = {


### PR DESCRIPTION
Fix ADG alerts as they are triggered rules not metrics so they do not need the treat missing data option